### PR TITLE
メッセージ送信機能を非同期通信化する

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,10 @@
 $(function() {
   function buildHTML(message){
-    if ( message.image ) {
-      var html = message.image.url? `<img src="${message.image.url}", class = 'lower-message__image'>` : "";
+    var img = ""
+    if (message.image !== null) {
+        img = `<img src="${message.image.url}">`
+    }
+      var html = 
        `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
@@ -14,30 +17,12 @@ $(function() {
           <div class="lower-message">
             <p class="lower-message__content">
               ${message.content}
-            </p>
-          </div>
-          <asset_path src=${message.image} >
-        </div>`
-      return html;
-    } else {
-      var html =
-       `<div class="message" data-message-id=${message.id}>
-          <div class="upper-message">
-            <div class="upper-message__user-name">
-              ${message.user_name}
-            </div>
-            <div class="upper-message__date">
-              ${message.date}
-            </div>
-          </div>
-          <div class="lower-message">
-            <p class="lower-message__content">
-              ${message.content}
+              ${img}
             </p>
           </div>
         </div>`
       return html;
-    };
+     
   }
 $('#new_message').on('submit', function(e){
   e.preventDefault();

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,7 @@
 $(function() {
   function buildHTML(message){
-    if ( message.image ) {
+    if (message.image!=null){
+      html += `<img src='${ message.image }', class='lower-message__image'>`
       var html =
        `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
@@ -52,7 +53,6 @@ $('#new_message').on('submit', function(e){
     contentType: false
    })
    .done(function(data){
-     console.log('hoge');
     var html = buildHTML(data);
     $('.messages').append(html);
     $('.form__message').val('');
@@ -61,9 +61,9 @@ $('#new_message').on('submit', function(e){
     $('form')[0].reset();
    })
   .fail(function(){
-    alert('error')
+    alert('メッセージを入力してください')
     $('.form__submit').prop('disabled', false);
     });
-    //return false;
+  
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,7 +55,6 @@ $('#new_message').on('submit', function(e){
    .done(function(data){
     var html = buildHTML(data);
     $('.messages').append(html);
-    $('.form__message').val('');
     $('.form__submit').prop('disabled', false); 
     $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');  
     $('form')[0].reset();

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,69 @@
+$(function() {
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="message" data-message-id=${message.id}>
+          <div class="upper-message">
+            <div class="upper-message__user-name">
+              ${message.user_name}
+            </div>
+            <div class="upper-message__date">
+              ${message.date}
+            </div>
+          </div>
+          <div class="lower-message">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+          <asset_path src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+       `<div class="message" data-message-id=${message.id}>
+          <div class="upper-message">
+            <div class="upper-message__user-name">
+              ${message.user_name}
+            </div>
+            <div class="upper-message__date">
+              ${message.date}
+            </div>
+          </div>
+          <div class="lower-message">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
+$('#new_message').on('submit', function(e){
+  e.preventDefault();
+  var formData = new FormData(this);
+  var url = $(this).attr('action')
+  $.ajax({
+    url: url,
+    type: "POST",
+    data: formData,
+    dataType: 'json',
+    processData: false,
+    contentType: false
+   })
+   .done(function(data){
+     console.log('hoge');
+    var html = buildHTML(data);
+    $('.messages').append(html);
+    $('.form__message').val('');
+    $('.form__submit').prop('disabled', false); 
+    $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');  
+    $('form')[0].reset();
+   })
+  .fail(function(){
+    alert('error')
+    $('.form__submit').prop('disabled', false);
+    });
+    //return false;
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,7 @@
 $(function() {
   function buildHTML(message){
-    if (message.image!=null){
-      html += `<img src='${ message.image }', class='lower-message__image'>`
-      var html =
+    if ( message.image ) {
+      var html = message.image.url? `<img src="${message.image.url}", class = 'lower-message__image'>` : "";
        `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,8 +19,8 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-       format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
-       format.json
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
     end
     else
       @messages = @group.messages.includes(:user)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,11 +5,23 @@ class MessagesController < ApplicationController
     @message = Message.new
     @messages = @group.messages.includes(:user)
   end
+  
+  def edit
+  end
+
+  def update
+      @message = @group.messages.find(params[:id])
+      @message.content = params[:content]
+  end
+  
 
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+       format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+       format.json
+    end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def index
+    @users = User.where('name LIKE(?) and id != ?', "#{params[:keyword]}%" ,current_user)
   end
 
   def edit

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,6 @@
+json.id @message.id
+json.user_name @message.user.name
+json.date @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url
+json.user_id  @message.user.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,4 +1,8 @@
-.chat
+.wrapper
+ 
+  = render 'messages/side_bar'
+
+  .chat
     .header
       .left-header
         .left-header__title
@@ -16,20 +20,10 @@
           Edit
 
     .messages
-      .message
-        .upper-message
-          .upper-message__user-name
-            = message.user.name
-          .upper-message__date
-            = message.created_at.strftime("%Y/%m/%d %H:%M")
-        .lower-meesage
-          - if message.content.present?
-            %p.lower-message__content
-              = message.content
-          = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+      = render @messages
 
     .form
-      = form_for [@group, @message] do |f|
+      = form_for([@group, @message], html:{id: 'new_message'}) do |f|
         = f.text_field :content, class: 'form__message', placeholder: 'type a message'
         .form__mask
           = f.label :image, class: 'form__mask__image' do

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,4 +1,4 @@
-.account-page.account-page
+#account-page.account-page
   .account-page__inner.clearfix
     .account-page__inner--left.account-page__header
       %h2 Edit Account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resources :users, only: [ :edit, :update]
+  resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :messages,only: [:index, :create]
+    resources :messages,only: [:index, :create, :edit, :update]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   end
 end  


### PR DESCRIPTION
#WHAT
メッセージ送信機能を非同期通信化する

作成したHTMLをメッセージ画面の一番下に追加する
HTMLを追加した分、メッセージ画面を下にスクロールする
連続で送信ボタンを押せるようにする
非同期に失敗した場合の処理も準備する


#WHY
メッセージを送信するたびに送信画面にリダイレクトしているため、ビューが毎回再描画されてしまうということを改善し必要なデータを返せるようにするために必要。

